### PR TITLE
Adding default shell format and write password

### DIFF
--- a/mountkey
+++ b/mountkey
@@ -22,11 +22,11 @@ echo -e -n "$vert"sda,sda1...?:
 read entre 
 
 #execute commande
-sudo mount -t vfat -o rw /dev/"$entre" /media/usbkey
+echo "your_password" | sudo -S mount -t vfat -o rw /dev/"$entre" /media/usbkey
 #detecte erreur
 if [ $? -gt 0 ];
 then
-    echo -e "$rouge""Erreur !"
+    echo -e "$rouge""[warn] Une erreur est survenu lors du montage de la clé usb."
     exit 1
 fi
 #information fin


### PR DESCRIPTION
Adding default shell format for the error message. Complete sudo -S and echo password : for some people it's impossible to use ssh because the script wait for root password.

Ajout du message d'erreur au format shell sur l'écran de démarrage.
Pour certaine personne le script demande le mot de passe root et bloque la suite du démarrage.
Le ssh n'est donc pas encore disponible et cela pose problème. 